### PR TITLE
Use vim-scripts to bundle lh-vim-lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ support subversion repositories like Vundle, you can install alerque's mirror
 of lh-vim-lib on github.
 
 ```vim
-Bundle 'alerque/lh-vim-lib'                                          
+Bundle 'vim-scripts/lh-vim-lib'                                          
 Bundle 'LucHermitte/local_vimrc'
 ```
 


### PR DESCRIPTION
The alerque repo is out of date and is incompatible with local_vimrc. I was able to get it to work with just `vim-scripts/lh-vim-lib`
